### PR TITLE
Hint at escaping spaces in Linux .desktop file example

### DIFF
--- a/desktop/Little Navconnect.desktop
+++ b/desktop/Little Navconnect.desktop
@@ -1,10 +1,12 @@
 [Desktop Entry]
 Type=Application
-Exec=YOUR_PATH_TO_LITTLENAVCONNECT/littlenavconnect
-Path=YOUR_PATH_TO_LITTLENAVCONNECT/
+Exec='YOUR_PATH/Little Navmap/Little Navconnect/littlenavconnect'
+# replace spaces with \s
+Path=YOUR_PATH/Little\sNavmap/Little\sNavconnect
+# replace spaces with \s
+Icon=YOUR_PATH/Little\sNavmap/Little\sNavconnect/littlenavconnect.svg
 Name=Little Navconnect
 GenericName=Little Navconnect
-Icon=YOUR_PATH_TO_LITTLENAVMAP/littlenavconnect.svg
 Terminal=false
 Categories=Qt;Utility;Geography;Maps;
 


### PR DESCRIPTION
In a default download and install, one has to deal with spaces in paths
for the Freedesktop .desktop file.

This can cause some grief so I propose to add that to the example.

The specs can be found here:
https://specifications.freedesktop.org/desktop-entry-spec/latest/
